### PR TITLE
Fix short trajectory plotting

### DIFF
--- a/physical_validation/util/kinetic_energy.py
+++ b/physical_validation/util/kinetic_energy.py
@@ -164,7 +164,10 @@ def check_distribution(
                 "\nFor smooth histograms, we recommend at least {} bins and {} data points per bin.\n"
                 "Your current trajectory has only {} data points.\n"
                 "Setting number of bins to {}. Consider a longer trajectory for smoother "
-                "histograms!".format(min_num_hist_bins, min_num_data_per_bin, len(kin), min_num_hist_bins))
+                "histograms!".format(
+                    min_num_hist_bins, min_num_data_per_bin, len(kin), min_num_hist_bins
+                )
+            )
         num_hist_bins = max(min_num_hist_bins, int(len(kin) / min_num_data_per_bin))
 
         data = [

--- a/physical_validation/util/kinetic_energy.py
+++ b/physical_validation/util/kinetic_energy.py
@@ -173,7 +173,7 @@ def check_distribution(
         data = [
             {
                 "y": kin,
-                "hist": max(5, num_hist_bins),
+                "hist": max(min_num_hist_bins, num_hist_bins),
                 "args": dict(label="Trajectory", density=True, alpha=0.5),
             }
         ]

--- a/physical_validation/util/kinetic_energy.py
+++ b/physical_validation/util/kinetic_energy.py
@@ -155,10 +155,22 @@ def check_distribution(
         if temp_unit is not None:
             tunit = temp_unit
 
+        # The following settings usually result in smooth histograms,
+        # but can be reconsidered
+        min_num_hist_bins = 5
+        min_num_data_per_bin = 150
+        if (int(len(kin) / min_num_data_per_bin)) < min_num_hist_bins:
+            warnings.warn(
+                "\nFor smooth histograms, we recommend at least {} bins and {} data points per bin.\n"
+                "Your current trajectory has only {} data points.\n"
+                "Setting number of bins to {}. Consider a longer trajectory for smoother "
+                "histograms!".format(min_num_hist_bins, min_num_data_per_bin, len(kin), min_num_hist_bins))
+        num_hist_bins = max(min_num_hist_bins, int(len(kin) / min_num_data_per_bin))
+
         data = [
             {
                 "y": kin,
-                "hist": int(len(kin) / 150),
+                "hist": max(5, num_hist_bins),
                 "args": dict(label="Trajectory", density=True, alpha=0.5),
             }
         ]


### PR DESCRIPTION
## Description
Histogram plotting was requiring 150 data points per bin, and didn't prevent having zero bins if the trajectory was shorter. Fixed by explaining the reasoning in a warning, and proceeding with a minimum number of bins if trajectory is shorter.

## Todos
  - [x] Fixes #76

## Status
- [x] Ready to go → #78 should go in first!