### PR TITLE
Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
### Description
This PR (mostly*) setups Dependabot in this repo. It is a dependency management bot that periodically checks the dependency versions and automatically opens PRs when new versions of upstream packages are released. Here, it's set up to scan the versions of the actions in the Github Actions scripts and update when there are changes. For example, [this](https://github.com/shirtsgroup/physical_validation/blob/628e7199ff182ecd331f19b282ce7a056c12295b/.github/workflows/lint.yaml#L15) action has been bumped to a `@v2`. (The bot updates against how strict the pin is; so here, with a major version specified, it would only open a PR if/when a `@v3` happens. If it was pinned to a patch version it would open a PR whenever a patch version is released.)

* Step 0 [here](https://github.com/openforcefield/status/pull/20#issuecomment-726129190) does need to be done by somebody else, if we want this, as I don't have permissions in this organization.