### PR TITLE
Fix examples linting

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -26,11 +26,14 @@ jobs:
       - name: Run isort
         run: |
           isort --recursive --check-only physical_validation
+          isort --recursive --check-only examples
 
       - name: Run black
         run: |
           black physical_validation --check
+          black examples --check
 
       - name: Run flake8
         run: |
           flake8 physical_validation
+          flake8 examples

--- a/examples/argon_integrator/ana_argon.py
+++ b/examples/argon_integrator/ana_argon.py
@@ -1,41 +1,46 @@
-import physical_validation as pv
 import os
 
-systems = ['none', 'shift', 'switch']
+import physical_validation as pv
+
+systems = ["none", "shift", "switch"]
 n_dts = 6
 
 # change this to fit to your GROMACS installation
-parser = pv.data.GromacsParser(exe='~/bin/gromacs/bin/gmx_d',
-                               includepath='~/bin/gromacs/share/gromacs/top')
+parser = pv.data.GromacsParser(
+    exe="~/bin/gromacs/bin/gmx_d", includepath="~/bin/gromacs/share/gromacs/top"
+)
 
 for sys in systems:
-    print('### Analyzing system ' + sys)
-    print('## Reading results')
+    print("### Analyzing system " + sys)
+    print("## Reading results")
     res = []
     # base simulation
-    dir = os.path.join(sys, 'base')
-    res.append(parser.get_simulation_data(
-        mdp=os.path.join(dir, 'mdout.mdp'),
-        top=os.path.join(dir, 'system.top'),
-        gro=os.path.join(dir, 'system.gro'),
-        edr=os.path.join(dir, 'system.edr')
-    ))
+    dir = os.path.join(sys, "base")
+    res.append(
+        parser.get_simulation_data(
+            mdp=os.path.join(dir, "mdout.mdp"),
+            top=os.path.join(dir, "system.top"),
+            gro=os.path.join(dir, "system.gro"),
+            edr=os.path.join(dir, "system.edr"),
+        )
+    )
 
-    for n in range(1, n_dts-1):
-        dir = os.path.join(sys, 'integrator_' + str(n))
-        res.append(parser.get_simulation_data(
-            mdp=os.path.join(dir, 'mdout.mdp'),
-            top=os.path.join(dir, 'system.top'),
-            gro=os.path.join(dir, 'system.gro'),
-            edr=os.path.join(dir, 'system.edr')
-        ))
+    for n in range(1, n_dts - 1):
+        dir = os.path.join(sys, "integrator_" + str(n))
+        res.append(
+            parser.get_simulation_data(
+                mdp=os.path.join(dir, "mdout.mdp"),
+                top=os.path.join(dir, "system.top"),
+                gro=os.path.join(dir, "system.gro"),
+                edr=os.path.join(dir, "system.edr"),
+            )
+        )
 
     # make plot directory
-    if not os.path.exists('ana_argon_plots'):
-        os.makedirs('ana_argon_plots')
-    sysplot = os.path.join('ana_argon_plots', sys)
-    
-    print('## Validating integrator convergence')
-    pv.integrator.convergence(res, verbose=True,
-                              filename=sysplot)
+    if not os.path.exists("ana_argon_plots"):
+        os.makedirs("ana_argon_plots")
+    sysplot = os.path.join("ana_argon_plots", sys)
+
+    print("## Validating integrator convergence")
+    pv.integrator.convergence(res, verbose=True, filename=sysplot)
     print()

--- a/examples/water_ensemble/ana_water.py
+++ b/examples/water_ensemble/ana_water.py
@@ -1,63 +1,67 @@
-import physical_validation as pv
 import os
 
-systems = ['vr', 'be', 'vr_pr', 'be_pr']
+import physical_validation as pv
+
+systems = ["vr", "be", "vr_pr", "be_pr"]
 
 # change this to fit to your GROMACS installation
-parser = pv.data.GromacsParser(exe='~/bin/gromacs/bin/gmx',
-                               includepath='~/bin/gromacs/share/gromacs/top')
+parser = pv.data.GromacsParser(
+    exe="~/bin/gromacs/bin/gmx", includepath="~/bin/gromacs/share/gromacs/top"
+)
 
 for sys in systems:
-    print('### Analyzing system ' + sys)
-    print('## Reading lower temperature result')
-    dir_low = os.path.join(sys, 'base')
+    print("### Analyzing system " + sys)
+    print("## Reading lower temperature result")
+    dir_low = os.path.join(sys, "base")
     res_low = parser.get_simulation_data(
-        mdp=os.path.join(dir_low, 'mdout.mdp'),
-        top=os.path.join(dir_low, 'system.top'),
-        gro=os.path.join(dir_low, 'system.gro'),
-        edr=os.path.join(dir_low, 'system.edr')
+        mdp=os.path.join(dir_low, "mdout.mdp"),
+        top=os.path.join(dir_low, "system.top"),
+        gro=os.path.join(dir_low, "system.gro"),
+        edr=os.path.join(dir_low, "system.edr"),
     )
-    print('## Reading high temperature result')
-    dir_high = os.path.join(sys, 'ensemble_1')
+    print("## Reading high temperature result")
+    dir_high = os.path.join(sys, "ensemble_1")
     res_high = parser.get_simulation_data(
-        mdp=os.path.join(dir_high, 'mdout.mdp'),
-        top=os.path.join(dir_high, 'system.top'),
-        gro=os.path.join(dir_high, 'system.gro'),
-        edr=os.path.join(dir_high, 'system.edr')
+        mdp=os.path.join(dir_high, "mdout.mdp"),
+        top=os.path.join(dir_high, "system.top"),
+        gro=os.path.join(dir_high, "system.gro"),
+        edr=os.path.join(dir_high, "system.edr"),
     )
 
-    if not os.path.exists('ana_water_plots'):
-        os.makedirs('ana_water_plots')
-    sysplot = os.path.join('ana_water_plots', sys)
-    
-    print('\n## Validating kinetic energy distribution (strict)')
-    print('# Low T:')
-    pv.kinetic_energy.distribution(res_low, verbosity=2, strict=True,
-                                   filename=sysplot + '_low_mb')
-    print('# High T:')
-    pv.kinetic_energy.distribution(res_high, verbosity=2, strict=True,
-                                   filename=sysplot + '_high_mb')
+    if not os.path.exists("ana_water_plots"):
+        os.makedirs("ana_water_plots")
+    sysplot = os.path.join("ana_water_plots", sys)
 
-    print('\n## Validating kinetic energy distribution (non-strict)')
-    print('# Low T:')
+    print("\n## Validating kinetic energy distribution (strict)")
+    print("# Low T:")
+    pv.kinetic_energy.distribution(
+        res_low, verbosity=2, strict=True, filename=sysplot + "_low_mb"
+    )
+    print("# High T:")
+    pv.kinetic_energy.distribution(
+        res_high, verbosity=2, strict=True, filename=sysplot + "_high_mb"
+    )
+
+    print("\n## Validating kinetic energy distribution (non-strict)")
+    print("# Low T:")
     pv.kinetic_energy.distribution(res_low, verbosity=2, strict=False)
-    print('# High T:')
+    print("# High T:")
     pv.kinetic_energy.distribution(res_high, verbosity=2, strict=False)
-    
-    print('\n## Validating ensemble')
-    if 'pr' in sys:
+
+    print("\n## Validating ensemble")
+    if "pr" in sys:
         # can't plot in 2d...
         quantiles = pv.ensemble.check(res_low, res_high, verbosity=2)
     else:
-        quantiles = pv.ensemble.check(res_low, res_high, verbosity=2,
-                                      filename=sysplot + '_ensemble')
+        quantiles = pv.ensemble.check(
+            res_low, res_high, verbosity=2, filename=sysplot + "_ensemble"
+        )
     if len(quantiles) == 1:
-        q_str = '{:.1f}'.format(quantiles[0])
+        q_str = "{:.1f}".format(quantiles[0])
     else:
-        q_str = '('
+        q_str = "("
         for q in quantiles:
-            q_str += '{:.1f}, '.format(q)
-        q_str = q_str[:-2] + ')'
-    print('Calculated slope is ' + q_str +
-          ' quantiles from the true slope')
-    print('\n')
+            q_str += "{:.1f}, ".format(q)
+        q_str = q_str[:-2] + ")"
+    print("Calculated slope is " + q_str + " quantiles from the true slope")
+    print("\n")


### PR DESCRIPTION
## Description
Fixes the formatting of the example scripts.

## Todos
  - [x] Fix formatting and import sorting for example scripts
  - [x] Enable linting checks for the examples folder

## Status
- [x] Ready to go