### PR TITLE
Expose bootstrapping seed for ensemble checks

### DIFF
--- a/physical_validation/ensemble.py
+++ b/physical_validation/ensemble.py
@@ -49,6 +49,7 @@ def check(
     total_energy=False,
     bs_error=False,
     bs_repetitions=200,
+    bs_seed=None,
     screen=False,
     filename=None,
     verbosity=1,
@@ -68,6 +69,10 @@ def check(
     bs_repetitions : int
         Number of bootstrap repetitions drawn
         Default: 200
+    bs_seed : int
+        Sets the random number seed for bootstrapping.
+        If set, bootstrapping will be reproducible.
+        Default: None, bootstrapping is non-reproducible.
     screen : bool
         Plot distributions on screen. Default: False.
     filename : string
@@ -134,6 +139,7 @@ def check(
             quantity=eneq,
             dtemp=True,
             dpress=False,
+            seed=bs_seed,
             bs_error=bs_error,
             bs_repetitions=bs_repetitions,
             verbosity=verbosity,
@@ -193,6 +199,7 @@ def check(
                 quantity=eneq,
                 dtemp=True,
                 dpress=False,
+                seed=bs_seed,
                 bs_error=bs_error,
                 bs_repetitions=bs_repetitions,
                 verbosity=verbosity,
@@ -211,6 +218,7 @@ def check(
                 quantity="V",
                 dtemp=False,
                 dpress=True,
+                seed=bs_seed,
                 temp=temperatures[0],
                 pvconvert=pvconvert,
                 bs_error=bs_error,
@@ -235,6 +243,7 @@ def check(
                 pvconvert=pvconvert,
                 quantity=[eneq, "V"],
                 dtempdpress=True,
+                seed=bs_seed,
                 bs_error=bs_error,
                 bs_repetitions=bs_repetitions,
                 verbosity=verbosity,


### PR DESCRIPTION
## Description
Expose bootstrapping seed for ensemble checks to allow for reproducible error estimates. The functionality to set the seed was already implemented in the lower-level functions, but it wasn't exposed to the user-facing functions. Exposing this will simplify comparing results for end-to-end tests. #86 implements the bootstrapping seed for kinetic energy tests.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Expose bootstrapping seed to user-facing functions for ensemble checks.

## Status
- [x] Ready to go