### PR TITLE
Implement bootstrapping seed for kinetic energy checks

### DIFF
--- a/physical_validation/kinetic_energy.py
+++ b/physical_validation/kinetic_energy.py
@@ -36,7 +36,13 @@ from .util import kinetic_energy as util_kin
 
 
 def distribution(
-    data, strict=False, verbosity=2, screen=False, filename=None, bs_repetitions=200
+    data,
+    strict=False,
+    verbosity=2,
+    screen=False,
+    filename=None,
+    bs_repetitions=200,
+    bs_seed=None,
 ):
     r"""Checks the distribution of a kinetic energy trajectory.
 
@@ -57,6 +63,10 @@ def distribution(
     bs_repetitions : int
         Number of bootstrap samples used for error estimate (if strict=False).
         Default: 200.
+    bs_seed : int
+        Sets the random number seed for bootstrapping (if strict=False).
+        If set, bootstrapping will be reproducible.
+        Default: None, bootstrapping is non-reproducible.
 
     Returns
     -------
@@ -149,6 +159,7 @@ def distribution(
             kb=data.units.kb,
             verbosity=verbosity,
             bs_repetitions=bs_repetitions,
+            bs_seed=bs_seed,
             screen=screen,
             filename=filename,
             ene_unit=data.units.energy_str,

--- a/physical_validation/util/kinetic_energy.py
+++ b/physical_validation/util/kinetic_energy.py
@@ -210,6 +210,7 @@ def check_mean_std(
     kb,
     verbosity=2,
     bs_repetitions=200,
+    bs_seed=None,
     screen=False,
     filename=None,
     ene_unit=None,
@@ -246,6 +247,10 @@ def check_mean_std(
         Default: 2.
     bs_repetitions : int
         Number of bootstrap samples used for error estimate. Default: 200.
+    bs_seed : int
+        Sets the random number seed for bootstrapping.
+        If set, bootstrapping will be reproducible.
+        Default: None, bootstrapping is non-reproducible.
     screen : bool
         Plot distributions on screen. Default: False.
     filename : string
@@ -291,6 +296,8 @@ def check_mean_std(
     # ======================== #
     # Bootstrap error estimate #
     # ======================== #
+    if bs_seed is not None:
+        np.random.seed(bs_seed)
     mu = []
     sig = []
     for k in trajectory.bootstrap(kin, bs_repetitions):


### PR DESCRIPTION
Implement bootstrapping seed for ensemble checks to allow for reproducible error estimates. Implementing this will simplify comparing results for end-to-end tests. #85 exposes the bootstrapping seed for ensemble checks.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Implement bootstrapping seed to user-facing functions in kinetic energy checks.

## Status
- [x] Ready to go