### PR TITLE
Allow user to choose plot file format

### DIFF
--- a/doc/userguide.rst
+++ b/doc/userguide.rst
@@ -257,10 +257,10 @@ can be validated via the strict test as follows:
    print('\n## Validating kinetic energy distribution (strict)')
    print('# Low T:')
    pv.kinetic_energy.distribution(res_low, verbosity=2, strict=True,
-                                  filename=sysplot + '_low_mb')
+                                  filename=sysplot + '_low_mb.pdf')
    print('# High T:')
    pv.kinetic_energy.distribution(res_high, verbosity=2, strict=True,
-                                  filename=sysplot + '_high_mb')
+                                  filename=sysplot + '_high_mb.pdf')
 
 This will plot the sampled distribution along with its analytical counterpart,
 and print out the result of the analysis. For the NVT simulation
@@ -348,7 +348,7 @@ relevant line of code reads
 
    print('\n## Validating ensemble')
    quantiles = pv.ensemble.check(res_low, res_high, quiet=False,
-                                 screen=False, filename=sysplot + '_ensemble')
+                                 screen=False, filename=sysplot + '_ensemble.pdf')
 
 The ensemble validation function uses the two simulation results at lower and
 higher state point to calculate the ratio of the energy distributions and

--- a/examples/argon_integrator/ana_argon.py
+++ b/examples/argon_integrator/ana_argon.py
@@ -39,7 +39,7 @@ for sys in systems:
     # make plot directory
     if not os.path.exists("ana_argon_plots"):
         os.makedirs("ana_argon_plots")
-    sysplot = os.path.join("ana_argon_plots", sys)
+    sysplot = os.path.join("ana_argon_plots", sys + ".pdf")
 
     print("## Validating integrator convergence")
     pv.integrator.convergence(res, verbose=True, filename=sysplot)

--- a/examples/water_ensemble/ana_water.py
+++ b/examples/water_ensemble/ana_water.py
@@ -35,11 +35,11 @@ for sys in systems:
     print("\n## Validating kinetic energy distribution (strict)")
     print("# Low T:")
     pv.kinetic_energy.distribution(
-        res_low, verbosity=2, strict=True, filename=sysplot + "_low_mb"
+        res_low, verbosity=2, strict=True, filename=sysplot + "_low_mb.pdf"
     )
     print("# High T:")
     pv.kinetic_energy.distribution(
-        res_high, verbosity=2, strict=True, filename=sysplot + "_high_mb"
+        res_high, verbosity=2, strict=True, filename=sysplot + "_high_mb.pdf"
     )
 
     print("\n## Validating kinetic energy distribution (non-strict)")
@@ -54,7 +54,7 @@ for sys in systems:
         quantiles = pv.ensemble.check(res_low, res_high, verbosity=2)
     else:
         quantiles = pv.ensemble.check(
-            res_low, res_high, verbosity=2, filename=sysplot + "_ensemble"
+            res_low, res_high, verbosity=2, filename=sysplot + "_ensemble.pdf"
         )
     if len(quantiles) == 1:
         q_str = "{:.1f}".format(quantiles[0])

--- a/physical_validation/ensemble.py
+++ b/physical_validation/ensemble.py
@@ -71,7 +71,8 @@ def check(
     screen : bool
         Plot distributions on screen. Default: False.
     filename : string
-        Plot distributions to `filename`.pdf. Default: None.
+        Plot distributions to `filename`.
+        Default: None, no plotting to file.
     verbosity : int
         Level of verbosity, from 0 (quiet) to 3 (very verbose).
         Default: 1

--- a/physical_validation/integrator.py
+++ b/physical_validation/integrator.py
@@ -59,7 +59,7 @@ def convergence(
     screen : bool
         Plot convergence on screen. Default: False.
     filename : string
-        Plot convergence to `filename`.pdf. Default: None.
+        Plot convergence to `filename`. Default: None, no plotting to file.
 
     Returns
     -------

--- a/physical_validation/kinetic_energy.py
+++ b/physical_validation/kinetic_energy.py
@@ -57,7 +57,7 @@ def distribution(
     screen : bool, optional
         Plot distributions on screen. Default: False.
     filename : string, optional
-        Plot distributions to `filename`.pdf. Default: None.
+        Plot distributions to `filename`. Default: None, no plotting to file.
     bs_repetitions : int
         Number of bootstrap samples used for error estimate (if strict=False).
         Default: 200.
@@ -202,7 +202,7 @@ def equipartition(
     screen : bool
         Plot distributions on screen. Default: False.
     filename : string
-        Plot distributions to `filename`.pdf. Default: None.
+        Plot distributions to `filename`. Default: None, no plotting to file
 
     Returns
     -------

--- a/physical_validation/util/ensemble.py
+++ b/physical_validation/util/ensemble.py
@@ -695,7 +695,7 @@ def check_1d(
         Plot distributions on screen.
         Default: False.
     filename : string, optional
-        Plot distributions to `filename`.pdf.
+        Plot distributions to `filename`.
         Default: None.
     xlabel : string, optional
         x-axis label used for plotting
@@ -1054,7 +1054,7 @@ def check_2d(
         Plot distributions on screen.
         Default: False.
     filename : string, optional
-        Plot distributions to `filename`.pdf.
+        Plot distributions to `filename`.
         Default: None.
 
     Returns

--- a/physical_validation/util/kinetic_energy.py
+++ b/physical_validation/util/kinetic_energy.py
@@ -114,7 +114,7 @@ def check_distribution(
     screen : bool
         Plot distributions on screen. Default: False.
     filename : string
-        Plot distributions to `filename`.pdf. Default: None.
+        Plot distributions to `filename`. Default: None.
     ene_unit : string
         Energy unit - used for output only.
     temp_unit : string
@@ -267,7 +267,7 @@ def check_mean_std(
     screen : bool
         Plot distributions on screen. Default: False.
     filename : string
-        Plot distributions to `filename`.pdf. Default: None.
+        Plot distributions to `filename`. Default: None.
     ene_unit : string
         Energy unit - used for output only.
     temp_unit : string
@@ -515,7 +515,7 @@ def check_equipartition(
     screen : bool
         Plot distributions on screen. Default: False.
     filename : string
-        Plot distributions to `filename`.pdf. Default: None.
+        Plot distributions to `filename`. Default: None.
     ene_unit : string
         Energy unit - used for output only.
     temp_unit : string
@@ -1087,7 +1087,7 @@ def test_group(
     screen : bool
         Plot distributions on screen. Default: False.
     filename : string
-        Plot distributions to `filename`.pdf. Default: None.
+        Plot distributions to `filename`. Default: None.
     ene_unit : string
         Energy unit - used for output only.
     temp_unit : string

--- a/physical_validation/util/plot.py
+++ b/physical_validation/util/plot.py
@@ -162,7 +162,7 @@ def plot(
     ax.xaxis.major.formatter._useMathText = True
 
     if filename is not None:
-        fig.savefig(filename + ".pdf", dpi=300)
+        fig.savefig(filename, dpi=300)
     if screen:
         fig.show()
 


### PR DESCRIPTION
## Description
Currently, physical validation is only printing to pdf,
appending ".pdf" to any file name given by the user.
There is no reason for this restriction, so the current
change allows users to choose the filename AND the suffix
used for plotting.

## Todos
  - [x] Don't append ".pdf" to file name when plotting
  - [x] Update doc strings
  - [x] Update documentation

## Status
- [x] Ready to go