### PR TITLE
Fix estimate_interval return value

### DIFF
--- a/physical_validation/util/ensemble.py
+++ b/physical_validation/util/ensemble.py
@@ -595,6 +595,8 @@ def estimate_interval(
                 )
             )
 
+    return result
+
 
 def check_1d(
     traj1,


### PR DESCRIPTION
## Description
The estimate_interval functionality should be returning the calculated
interval for programmatic use of the function. The result dict to be
returned was generated in the low-level function, but not returned
to the user-facing function, which hence returned `None` instead of
the intended dict.

Closes #93

## Status
- [x] Ready to go