### PR TITLE
Fixed typos, missing docstrings, format issues, and minor mistakes of the whole documentation

### DIFF
--- a/doc/parsers.rst
+++ b/doc/parsers.rst
@@ -226,7 +226,7 @@ The information about units consists of different parts:
 * the conversion factor to GROMACS units (kJ/mol, nm, nm^3, K, bar, ps), and
 * the name of the units (energy_str, length_str, volume_str, temperature_str, pressure_str, time_str).
 The names are only used for output (console printing and plotting), and are optional.
-The conversion factors and $k_B$ are, on the other hand, used in computations and need
+The conversion factors and k_B are, on the other hand, used in computations and need
 to be given.
 
 Needed by

--- a/doc/parsers.rst
+++ b/doc/parsers.rst
@@ -8,7 +8,7 @@ of the  :class:`.SimulationData` type. While lower-level functions accepting
 bare arrays and numbers are available, the  :class:`.SimulationData` objects
 combine ease-of-use and higher stability in form of input testing.
 
-The  :class:`.SimulationData` objects are consisting of information about the
+The  :class:`.SimulationData` objects are consist of information about the
 simulation and the system. This information is collected in objects of different
 classes, namely
 
@@ -221,11 +221,12 @@ Attributes:
 * :attr:`.UnitData.time_str`, `str`
 
 The information about units consists of different parts:
+
 * The value of kB in the used energy units,
 * the conversion factor to GROMACS units (kJ/mol, nm, nm^3, K, bar, ps), and
 * the name of the units (energy_str, length_str, volume_str, temperature_str, pressure_str, time_str).
 The names are only used for output (console printing and plotting), and are optional.
-The conversion factors and kB are, on the other hand, used in computations and need
+The conversion factors and $k_B$ are, on the other hand, used in computations and need
 to be given.
 
 Needed by
@@ -251,7 +252,7 @@ Attributes:
 The ensemble is a string indicating the thermodynamical ensemble a simulation was
 performed in, and is any of 'NVE', 'NVT', 'NPT', 'muVT'.
 
-Depending on the ensemble, EnsembleData then holds additional information defining
+Depending on the ensemble, :class:`.EnsembleData` then holds additional information defining
 the ensemble, such as the number of particles N, the chemical potential mu, the
 volume V, the pressure P, the constant energy E or the temperature T. While any
 of these additional information are optional, most of them are needed by certain

--- a/doc/parsers.rst
+++ b/doc/parsers.rst
@@ -8,7 +8,7 @@ of the  :class:`.SimulationData` type. While lower-level functions accepting
 bare arrays and numbers are available, the  :class:`.SimulationData` objects
 combine ease-of-use and higher stability in form of input testing.
 
-The  :class:`.SimulationData` objects are consist of information about the
+The  :class:`.SimulationData` objects are consisting of information about the
 simulation and the system. This information is collected in objects of different
 classes, namely
 
@@ -226,7 +226,7 @@ The information about units consists of different parts:
 * the conversion factor to GROMACS units (kJ/mol, nm, nm^3, K, bar, ps), and
 * the name of the units (energy_str, length_str, volume_str, temperature_str, pressure_str, time_str).
 The names are only used for output (console printing and plotting), and are optional.
-The conversion factors and k_B are, on the other hand, used in computations and need
+The conversion factors and kB are, on the other hand, used in computations and need
 to be given.
 
 Needed by

--- a/doc/physical_validation.rst
+++ b/doc/physical_validation.rst
@@ -16,7 +16,7 @@ physical_validation\.ensemble module
 .. automodule:: physical_validation.ensemble
     :members:
 
-physical_validation\.integratorconvergence module
+physical_validation\.integrator.convergence module
 -------------------------------------------------
 
 .. automodule:: physical_validation.integrator

--- a/doc/physical_validation.rst
+++ b/doc/physical_validation.rst
@@ -16,8 +16,8 @@ physical_validation\.ensemble module
 .. automodule:: physical_validation.ensemble
     :members:
 
-physical_validation\.integrator.convergence module
---------------------------------------------------
+physical_validation\.integrator module
+--------------------------------------
 
 .. automodule:: physical_validation.integrator
     :members:

--- a/doc/physical_validation.rst
+++ b/doc/physical_validation.rst
@@ -17,7 +17,7 @@ physical_validation\.ensemble module
     :members:
 
 physical_validation\.integrator.convergence module
--------------------------------------------------
+--------------------------------------------------
 
 .. automodule:: physical_validation.integrator
     :members:

--- a/doc/userguide.rst
+++ b/doc/userguide.rst
@@ -90,14 +90,14 @@ the package. More specifically, the subfolders of `examples/` contain:
   the forces were altered in a way to have both the forces and the potential
   smoothly reaching zero at the cut-off distance. For each choice of interaction
   function, the same simulation was repeated five times, with each new simulation
-  having the integration time step compared to the previous one.
+  halving the integration time step compared to the previous one.
 
 For each example, the subfolders for individual simulations contain the following files:
 
 * `start.gro`: the starting configuration of the molecules/atoms
 * `system.top`: the topology of the system
 * `system.mdp`: the GROMACS input file
-* `mdout.mdp`: the GROMACS output file obtained from `gmx grompp`
+* `mdout.mdp`: the GROMACS parameters file obtained from `gmx grompp`
 * `system.gro`: the end configuration
 * `system.edr`: the resulting (binary) energy file
 
@@ -583,7 +583,7 @@ The outputs of the function are the time step, the average value of the
 constant of motion, and its RMSD during the simulation. The fourth
 column gives the measured slope of the constant of motion - a large
 value here would indicate a strong drift and hence a problem in the
-integrator. Even without a strong drift, as in the current situation, a
+integrator. Even without strong drift, as in the current situation, a
 large deviation in the ratio between the RMSD values compared to the
 ratio between the time step will indicate some error in the integrator.
 The reason for a failure of this test might not always be intuitively clear,

--- a/doc/userguide.rst
+++ b/doc/userguide.rst
@@ -90,14 +90,14 @@ the package. More specifically, the subfolders of `examples/` contain:
   the forces were altered in a way to have both the forces and the potential
   smoothly reaching zero at the cut-off distance. For each choice of interaction
   function, the same simulation was repeated five times, with each new simulation
-  halving the integration time step compared to the previous one.
+  having the integration time step compared to the previous one.
 
 For each example, the subfolders for individual simulations contain the following files:
 
 * `start.gro`: the starting configuration of the molecules/atoms
 * `system.top`: the topology of the system
 * `system.mdp`: the GROMACS input file
-* `mdout.mdp`: the GROMACS input file obtained from `gmx grompp`
+* `mdout.mdp`: the GROMACS output file obtained from `gmx grompp`
 * `system.gro`: the end configuration
 * `system.edr`: the resulting (binary) energy file
 
@@ -227,7 +227,7 @@ environment, keeping errors from other sources negligible is
 certainly desirable. In many other, real-world
 applications, however, a deviation insignificant in comparison with
 other sources of inaccuracies might be enough to flag long simulation
-trajectories of large systems as not having a gamma distributed. For
+trajectories of large systems as not having a gamma distribution. For
 example, deviations from the desired kinetic energy distribution that
 are smaller in magnitude than other well-controlled approximations, such as
 the interaction cutoff or the treatment of bond constraints, might be enough
@@ -312,6 +312,8 @@ The distribution sampled by the Berendsen algorithm is significantly too narrow.
     * sigma: 98.81 +- 1.03 kJ/mol
       T(sigma) = 228.78 +- 2.37 K
 
+For more details about the difference between the strict test and non-strict test, please
+see func:`physical_validation.kinetic_energy.distribution`.
 
 Ensemble validation
 ===================
@@ -429,7 +431,7 @@ using the total energy will in general not give any additional insights
 and might mask errors in the other energy terms.
 
 Support for grand and semigrand canonical ensembles, validating the
-distribution of $N$ and $U$ or composition will be provided soon; in
+distribution of :math:`N` and :math:`U` or composition will be provided soon; in
 the meantime, this functionality can still be found in the
 checkensemble_ repository.
 
@@ -581,7 +583,7 @@ The outputs of the function are the time step, the average value of the
 constant of motion, and its RMSD during the simulation. The fourth
 column gives the measured slope of the constant of motion - a large
 value here would indicate a strong drift and hence a problem in the
-integrator. Even without strong drift, as in the current situation, a
+integrator. Even without a strong drift, as in the current situation, a
 large deviation in the ratio between the RMSD values compared to the
 ratio between the time step will indicate some error in the integrator.
 The reason for a failure of this test might not always be intuitively clear,

--- a/physical_validation/data/observable_data.py
+++ b/physical_validation/data/observable_data.py
@@ -39,13 +39,13 @@ class ObservableData(object):
     r"""ObservableData: The trajectory of (macroscopic) observables during the simulation
 
     Stores a number of different observables:
-    'kinetic_energy': the kinetic energy of the system,
-    'potential_energy': the potential energy of the system,
-    'total_energy': the total energy of the system,
-    'volume': the volume of the system box,
-    'pressure': the pressure of the system,
-    'temperature': the temperature of the system,
-    'constant_of_motion': a constant of motion of the trajectory.
+    * kinetic_energy: the kinetic energy of the system,
+    * potential_energy: the potential energy of the system,
+    * total_energy: the total energy of the system,
+    * volume: the volume of the system box,
+    * pressure: the pressure of the system,
+    * temperature: the temperature of the system,
+    * constant_of_motion: a constant of motion of the trajectory.
 
     The observable trajectories can be accessed either using the getters of an object, as in
         observables.kinetic_energy

--- a/physical_validation/integrator.py
+++ b/physical_validation/integrator.py
@@ -56,6 +56,7 @@ def convergence(
         test is implemented:
         `max_deviation`
     verbose : bool, optional
+        If True, some output is printed
     screen : bool
         Plot convergence on screen. Default: False.
     filename : string
@@ -76,7 +77,7 @@ def convergence(
     hence expected to hold:
 
     .. math::
-        \frac{\Delta t_1}{\Delta t_2} = \frac{\delta E_1}{\delta E_2}
+        \frac{\Delta t_1^{2}}{\Delta t_2^{2}} = \frac{\delta E_1}{\delta E_2}
 
     This function calculates the ratio of the fluctuation for simulations
     performed at different timesteps and compares it to the analytically

--- a/physical_validation/integrator.py
+++ b/physical_validation/integrator.py
@@ -56,7 +56,7 @@ def convergence(
         test is implemented:
         `max_deviation`
     verbose : bool, optional
-        If True, some output is printed
+        If True, print more detailed output.
     screen : bool
         Plot convergence on screen. Default: False.
     filename : string

--- a/physical_validation/kinetic_energy.py
+++ b/physical_validation/kinetic_energy.py
@@ -112,7 +112,7 @@ def distribution(
 
         The test is performed using the Kolmogorov-Smirnov test provided by
         scipy.stats.kstest_. It returns the :math:`p`-value, measuring the
-        likelihood that a sample _at least as extreme_ as the one given is
+        likelihood that a sample at least as extreme as the one given is
         originating from the expected distribution.
 
         .. _scipy.stats.kstest: https://docs.scipy.org/doc/scipy-0.19.0/reference/generated/scipy.stats.kstest.html


### PR DESCRIPTION
## Description
This pull request is meant to address issue #49. Reading through the whole documentation thoroughly, I've fixed some typos, missing docstrings, format issues, and minor mistakes in the newly created branch `improve-documentation`. Overall, the documentation is very clear and beginner-friendly. Below are some notes/discussion points, some of which are minor but I'll just share all my thoughts.
- User guide 
  - There are a lot of output messages shown in the example in the section *Kinetic energy validation (full system)*, but I think it is not clear enough which output message corresponds to which parts of `ana_water.py`. I think it might be easier for the beginner to check the output (including the figures, which are not shown on the documentation page now) step by step if we set up the example in a jupyter notebook. Or if setting up jupyter notebooks is too tedious, we could just make clear which parts of the code did a certain part of the outputs came from. (We could put some of the important figures, which I think help the user to understand.)
  - Also, the output on the documentation page seems kind of different from the output messages from executing `ana_water.py`. We might want to fix this.
  - Not sure if it is better to include the key equations in each example in the user guide, e.g. the pdf of the kinetic energy showing that the gamma distribution. 
    - Update: I've added links to the documentation of the relevant functions, some of which had notes elaborating the related theory (e.g. the notes about the strict test checking the gamma distribution using K-S test). I think this sort of solves the problem.
  - We need an example for section *Kinetic energy validation (equipartition)*. I can help set that up in the near future if that's wanted.
  - The output messages of `ana_argon.py` are kind of different from the ones shown in the documentation (in the section of integrator validation). Do we want to make them consistent?
- Data format and parsers
  - In the example of using the flat file parser, I think it might be useful to provide example files `kinetic.dat`, `potential.dat`, and `total.dat`. 
    - Later found that the docstring of `physical_validation.data.flatfile_parser.FlatfileParser` did actually mention the format of the input files clearly, so attaching example files might not be needed. I'll just leave the comment here in case there is room for discussion. 
  - Some paragraphs mentioned units without using latex (e.g. nm^3). Do we want to use latex and make the format of all the units consistent? 
    - Also, the Boltzmann constant was written as kB instead of $k_{B}$ (e.g. the docstring of `physical_validation.data.unit_data`.)
  - Does the todos in the section "System: `SimulationData.system` of type `SystemData`" correspond to any issue? It might not be of high priority though.
- Package reference
  - The documentation of the argument `verbose` of `physical_validation.integrator.convergence` was missing (fixed). 

## Todos
**Update**: The todos as follows will be addressed in other issues/PRs. 
- [x] An example for the section [Kinetic energy validation (equipartition)](https://physical-validation.readthedocs.io/en/latest/userguide.html#kinetic-energy-validation-equipartition) (#102 )
- [x] Update the example outputs on the documentation to make sure they are consistent with the real outputs from `ana_water.py` and `ana_argon.py` (if there is a need to do so).

## Questions (Discussion points)
- [x] Whether we want to set up jupyter notebooks for the example or just improve the ones on the documentation (e.g. attaching the important figures).
- [x] Whether we want to provide example files like `kinetic.dat`, `potential.dat`, and `total.dat` for the example of using the flat file parser.
- [x] Whether there is a need to fix the font (latex or not) for units (and the Boltzmann constant).

## Status
- [x] Ready to go