### PR TITLE
Fix kinetic energy equipartition plotting

### DIFF
--- a/physical_validation/util/kinetic_energy.py
+++ b/physical_validation/util/kinetic_energy.py
@@ -165,7 +165,7 @@ def check_distribution(
         min_num_data_per_bin = 150
         if (int(len(kin) / min_num_data_per_bin)) < min_num_hist_bins:
             warnings.warn(
-                "\nFor smooth histograms, we recommend at least {} bins and {} data points per bin.\n"
+                "For smooth histograms, we recommend at least {} bins and {} data points per bin.\n"
                 "Your current trajectory has only {} data points.\n"
                 "Setting number of bins to {}. Consider a longer trajectory for smoother "
                 "histograms!".format(
@@ -1158,7 +1158,7 @@ def test_group(
         if filename is None:
             fn = None
         else:
-            fn = filename + "_" + key
+            fn = key + "_" + filename
         if strict:
             res = check_distribution(
                 kin=group_kin[key],


### PR DESCRIPTION
When changing the plotting filename to include the file suffix in #88,
the equipartition plotting got broken because adding a suffix for the
different tests after the filename did not work anymore. This changes
the differentiation of the different tests to a prefix, avoiding the
suffix problem.

## Status
- [x] Ready to go