### PR TITLE
Fix flat file parser trajectory frame break

### DIFF
--- a/physical_validation/data/flatfile_parser.py
+++ b/physical_validation/data/flatfile_parser.py
@@ -141,6 +141,7 @@ class FlatfileParser(parser.Parser):
         with open(filename) as f:
             frame = []
             for line in f:
+                line = line.strip()
                 if not line:
                     # blank line
                     if frame:


### PR DESCRIPTION
Fixes a bug that would cause the flat file parser to read entire
trajectories into a single frame instead of recognizing empty lines
as frame breaks.

## Status
- [x] Ready to go