### PR TITLE
Allow KE equilibration check to run without observable object

### DIFF
--- a/physical_validation/kinetic_energy.py
+++ b/physical_validation/kinetic_energy.py
@@ -15,6 +15,7 @@ The `kinetic_energy` module is part of the physical_validation package, and
 consists of checks of the kinetic energy distribution and its
 equipartition.
 """
+from .data import ObservableData
 from .util import kinetic_energy as util_kin
 
 
@@ -248,6 +249,11 @@ def equipartition(
     checks.
 
     """
+    if data.observables is None:
+        # The equipartition test doesn't need observable input, but uses the
+        # data structure to store information. Create it if it doesn't exist.
+        data.observables = ObservableData()
+
     (
         result,
         data.system.ndof_per_molecule,


### PR DESCRIPTION
KE equilibration doesn't need an observable object as input, but
uses it to store some values (which speeds up the run in case that
more than one test is run on the same simulation data). The addition
in this change allows the KE equilibration check to run even if the
input simulation data object did not initialize such an object.

## Status
- [x] Ready to go