### PR TITLE
Make equipartition random divisions reproducible

### DIFF
--- a/physical_validation/kinetic_energy.py
+++ b/physical_validation/kinetic_energy.py
@@ -166,6 +166,7 @@ def equipartition(
     molec_groups=None,
     random_divisions=0,
     random_groups=0,
+    random_division_seed=None,
     verbosity=2,
     screen=False,
     filename=None,
@@ -194,6 +195,9 @@ def equipartition(
         Number of random division tests attempted. Default: 0 (random division tests off).
     random_groups : int, optional
         Number of groups the system is randomly divided in. Default: 2.
+    random_division_seed : int, optional
+        Seed making the random divisions reproducible.
+        Default: None, random divisions not reproducible
     verbosity : int, optional
         Verbosity level, where 0 is quiet and 3 very chatty. Default: 2.
     screen : bool
@@ -274,6 +278,7 @@ def equipartition(
         molec_groups=molec_groups,
         random_divisions=random_divisions,
         random_groups=random_groups,
+        random_division_seed=random_division_seed,
         ndof_molec=data.system.ndof_per_molecule,
         kin_molec=data.observables.kinetic_energy_per_molecule,
         verbosity=verbosity,

--- a/physical_validation/util/kinetic_energy.py
+++ b/physical_validation/util/kinetic_energy.py
@@ -461,6 +461,7 @@ def check_equipartition(
     molec_groups=None,
     random_divisions=0,
     random_groups=2,
+    random_division_seed=None,
     ndof_molec=None,
     kin_molec=None,
     verbosity=2,
@@ -524,6 +525,9 @@ def check_equipartition(
         division tests off).
     random_groups : int, optional
         Number of groups the system is randomly divided in. Default: 2.
+    random_division_seed : int, optional
+        Seed making the random divisions reproducible.
+        Default: None, random divisions not reproducible
     ndof_molec : List[dict], optional
         Pass in the degrees of freedom per molecule. Slightly increases speed of repeated
         analysis of the same simulation run.
@@ -637,6 +641,8 @@ def check_equipartition(
     # ==================================== #
     # Check equipartition in random groups #
     # ==================================== #
+    if random_division_seed is not None:
+        np.random.seed(random_division_seed)
     for i in range(random_divisions):
         # randomly assign a group index to each molecule
         group_idx = np.random.randint(random_groups, size=nmolecs)


### PR DESCRIPTION
Adds an optional seed for the equipartition random divisions to make
them reproducible. This is mostly useful for testing purposes.

## Status
- [x] Ready to go