### PR TITLE
Small fixes to data objects equality and test system time steps

### DIFF
--- a/physical_validation/data/system_data.py
+++ b/physical_validation/data/system_data.py
@@ -269,6 +269,7 @@ class SystemData(object):
                 self.__nconstraints_per_molecule, other.__nconstraints_per_molecule
             )
             and np.array_equal(self.__ndof_per_molecule, other.__ndof_per_molecule)
-            and np.array_equal(self.__bonds, other.__bonds)
-            and np.array_equal(self.__constrained_bonds, other.__constrained_bonds)
+            # bonds are currently unused, so don't test for equality
+            # and np.array_equal(self.__bonds, other.__bonds)
+            # and np.array_equal(self.__constrained_bonds, other.__constrained_bonds)
         )

--- a/physical_validation/tests/test_system_database/system.py
+++ b/physical_validation/tests/test_system_database/system.py
@@ -73,7 +73,7 @@ class System:
                         'simulation_keys == "ensemble" can have at most 1 `time_step` input.'
                     )
                 if len(time_step) == 1:
-                    self.__time_step = {key : time_step[0] for key in self.__simulations}
+                    self.__time_step = {key: time_step[0] for key in self.__simulations}
         elif simulation_keys == "time step":
             if time_step is None:
                 raise ValueError(

--- a/physical_validation/tests/test_system_database/system.py
+++ b/physical_validation/tests/test_system_database/system.py
@@ -67,6 +67,13 @@ class System:
         self.__description = description
         if simulation_keys == "ensemble":
             self.__simulations = ensemble.keys()
+            if time_step is not None:
+                if len(time_step) > 1:
+                    raise ValueError(
+                        'simulation_keys == "ensemble" can have at most 1 `time_step` input.'
+                    )
+                if len(time_step) == 1:
+                    self.__time_step = {key : time_step[0] for key in self.__simulations}
         elif simulation_keys == "time step":
             if time_step is None:
                 raise ValueError(


### PR DESCRIPTION
This fixes two small inconveniences introduced recently:
* The equality function for the SystemData included checks for the
  bonds and constrained bonds functionality which is currently
  unused. Since these are unused, their presence should not be
  determining the equivalence of two objects.
* The test system time steps was only stored when it was being used
  as a simulation label. It can now also be stored otherwise.