### PR TITLE
Final check of the documentation

### DIFF
--- a/doc/examples/ensemble_check.ipynb
+++ b/doc/examples/ensemble_check.ipynb
@@ -30,8 +30,9 @@
    "id": "fad16a8f",
    "metadata": {},
    "source": [
-    "The results imported here are results from example simulations which are\n",
-    "stored in another Python file. In real-world usage, the results would\n",
+    "The results imported here are results from example simulations, which are\n",
+    "the time series of kinetic and potential energy stored in another Python \n",
+    "file. In real-world usage, the results would\n",
     "either come from the Python interface of the simulation package, from\n",
     "flat files containing the results, or from package-specific parsers. See\n",
     "[SimulationData](../simulation_data.rst)\n",

--- a/doc/examples/ensemble_check.ipynb
+++ b/doc/examples/ensemble_check.ipynb
@@ -30,9 +30,8 @@
    "id": "fad16a8f",
    "metadata": {},
    "source": [
-    "The results imported here are results from example simulations, which are\n",
-    "the time series of kinetic and potential energy stored in another Python \n",
-    "file. In real-world usage, the results would\n",
+    "The results imported here are the time series of kinetic and potential energy from example simulations, which are\n",
+    "stored in another Python file. In real-world usage, the results would\n",
     "either come from the Python interface of the simulation package, from\n",
     "flat files containing the results, or from package-specific parsers. See\n",
     "[SimulationData](../simulation_data.rst)\n",

--- a/doc/examples/integrator_validation.ipynb
+++ b/doc/examples/integrator_validation.ipynb
@@ -28,8 +28,8 @@
    "id": "ae2f8c5f",
    "metadata": {},
    "source": [
-    "The results imported here are results from example simulations which are\n",
-    "stored in another Python file. In real-world usage, the results would\n",
+    "The results imported here are results from example simulations, which are\n",
+    "the time series of kinetic and potential energy stored in another Python file. In real-world usage, the results would\n",
     "either come from the Python interface of the simulation package, from\n",
     "flat files containing the results, or from package-specific parsers. See\n",
     "[SimulationData](../simulation_data.rst)\n",
@@ -53,7 +53,7 @@
    "id": "930ae351",
    "metadata": {},
    "source": [
-    "The example system consists of 1000 Lennard-Jones (LJ) particles simulated under NVE conditions. To illustrate how the integrator convergence validation can pick up small errors in the simulation, the simulation were repeated with different interaction cutoff schemes. In all cases, the LJ interactions were discarded if the particles were more than 1 nm apart. Uncorrected, this leads to a small discontinuity in the potential and the force at the cutoff distance. A first approach to correct this discontinuity is by shifting the potential by a constant value such that it reaches 0 at the cutoff distance. This fixes the discontinuity in the potential, but does not alter the forces. A second approach is to smoothly switch off both the forces and the potential such that both reach zero at the cut-off distance.\n",
+    "The example system consists of 1000 Lennard-Jones (LJ) particles simulated under NVE conditions. To illustrate how the integrator convergence validation can pick up small errors in the simulation, the simulation were repeated with different interaction cutoff schemes. In all cases, the LJ interactions were discarded if the particles were more than 1 nm apart. Uncorrectly, this leads to a small discontinuity in the potential and the force at the cutoff distance. A first approach to correct this discontinuity is by shifting the potential by a constant value such that it reaches 0 at the cutoff distance. This fixes the discontinuity in the potential, but does not alter the forces. A second approach is to smoothly switch off both the forces and the potential such that both reach zero at the cut-off distance.\n",
     "\n",
     "The integrator validation analyzes the convergence of the fluctuations around the integrator constant of motion. For a symplectic integrator, the fluctuation is expected to be directly proportional to the square of the time step. The `physical_validation` check calculates the fluctuation convergence from multiple simulations with different time steps and validates the expectation."
    ]

--- a/doc/examples/integrator_validation.ipynb
+++ b/doc/examples/integrator_validation.ipynb
@@ -28,8 +28,8 @@
    "id": "ae2f8c5f",
    "metadata": {},
    "source": [
-    "The results imported here are results from example simulations, which are\n",
-    "the time series of kinetic and potential energy stored in another Python file. In real-world usage, the results would\n",
+    "The results imported here are the time series of kinetic and potential energy from example simulations, which are\n",
+    "stored in another Python file. In real-world usage, the results would\n",
     "either come from the Python interface of the simulation package, from\n",
     "flat files containing the results, or from package-specific parsers. See\n",
     "[SimulationData](../simulation_data.rst)\n",

--- a/doc/examples/kinetic_energy_distribution.ipynb
+++ b/doc/examples/kinetic_energy_distribution.ipynb
@@ -1272,7 +1272,9 @@
    "id": "0c4fddc2",
    "metadata": {},
    "source": [
-    "The non-strict test calculates the temperature of the mean and the width of the distribution. Analytically, we are expecting both to be close to 298.15K. The result confirms that the simulation behaves as expected, with both the calculated mean and variance being within one standard deviation of the analytical value. The returned tuple is the number of standard deviations the calculated mean and variance differ from the expected value - less than a standard deviations for the mean, and only about 0.05 standard deviations for the variance. Note that any deviation within about 2-3 standard deviations is usually considered as statistically insignificant."
+    "The non-strict test calculates the temperature of the mean and the width of the distribution. Analytically, we are expecting both to be close to 298.15K. The result confirms that the simulation behaves as expected, with both the calculated mean and variance being within one standard deviation of the analytical value. The returned tuple is the number of standard deviations the calculated mean and variance differ from the expected value - less than a standard deviations for the mean, and only about 0.05 standard deviations for the variance. Note that any deviation within about 2-3 standard deviations is usually considered as statistically insignificant.\n",
+    "\n",
+    "Also note that the error estimates were computed using bootstrapping and are hence a probabilistic quantity which will slightly differ when repeating the analysis."
    ]
   },
   {
@@ -2372,7 +2374,7 @@
    "id": "01b5371e",
    "metadata": {},
    "source": [
-    "The non-strict test confirms the conclusion from the strict test, but adds another explanation of the sampled distribution. The mean is found to be within about half a standard deviation of the expected value. The width of the sampled distribution, however, is what we would expect for a simulation at about 229K. This means that especially for simulations which rely on correct sampling of the tail regions, the Berendsen temperature coupling is likely to introduce artefacts. Again, the tuple returned here could be slightly different in different trials since no random seed was set."
+    "The non-strict test confirms the conclusion from the strict test, but adds another explanation of the sampled distribution. The mean is found to be within about half a standard deviation of the expected value. The width of the sampled distribution, however, is what we would expect for a simulation at about 229K. This means that especially for simulations which rely on correct sampling of the tail regions, the Berendsen temperature coupling is likely to introduce artefacts. Again, the tuple returned here could be slightly different in different trials due to its probabilistic nature."
    ]
   }
  ],

--- a/doc/examples/kinetic_energy_distribution.ipynb
+++ b/doc/examples/kinetic_energy_distribution.ipynb
@@ -30,8 +30,8 @@
    "id": "8f51f45d",
    "metadata": {},
    "source": [
-    "The results imported here are results from example simulations, which are\n",
-    "the time series of kinetic and potential energy stored in another Python file. In real-world usage, the results would\n",
+    "The results imported here are the time series of kinetic and potential energy from example simulations, which are\n",
+    "stored in another Python file. In real-world usage, the results would\n",
     "either come from the Python interface of the simulation package, from\n",
     "flat files containing the results, or from package-specific parsers. See\n",
     "[SimulationData](../simulation_data.rst)\n",

--- a/doc/examples/kinetic_energy_distribution.ipynb
+++ b/doc/examples/kinetic_energy_distribution.ipynb
@@ -30,8 +30,8 @@
    "id": "8f51f45d",
    "metadata": {},
    "source": [
-    "The results imported here are results from example simulations which are\n",
-    "stored in another Python file. In real-world usage, the results would\n",
+    "The results imported here are results from example simulations, which are\n",
+    "the time series of kinetic and potential energy stored in another Python file. In real-world usage, the results would\n",
     "either come from the Python interface of the simulation package, from\n",
     "flat files containing the results, or from package-specific parsers. See\n",
     "[SimulationData](../simulation_data.rst)\n",
@@ -2372,7 +2372,7 @@
    "id": "01b5371e",
    "metadata": {},
    "source": [
-    "The non-strict test confirms the conclusion from the strict test, but adds another explanation of the sampled distribution. The mean is found to be within about half a standard deviation of the expected value. The width of the sampled distribution, however, is what we would expect for a simulation at about 229K. This means that especially for simulations which rely on correct sampling of the tail regions, the Berendsen temperature coupling is likely to introduce artefacts."
+    "The non-strict test confirms the conclusion from the strict test, but adds another explanation of the sampled distribution. The mean is found to be within about half a standard deviation of the expected value. The width of the sampled distribution, however, is what we would expect for a simulation at about 229K. This means that especially for simulations which rely on correct sampling of the tail regions, the Berendsen temperature coupling is likely to introduce artefacts. Again, the tuple returned here could be slightly different in different trials since no random seed was set."
    ]
   }
  ],

--- a/doc/examples/kinetic_energy_equipartition.ipynb
+++ b/doc/examples/kinetic_energy_equipartition.ipynb
@@ -30,8 +30,8 @@
    "id": "2a3d8caf",
    "metadata": {},
    "source": [
-    "The results imported here are results from example simulations, which are\n",
-    "the time series of the kinetic/potential energy, position and velocity stored in another Python file. In real-world usage, the results would\n",
+    "The results imported here are the time series of kinetic and potential energy, positions and velocities from example simulations, which are\n",
+    "stored in another Python file. In real-world usage, the results would\n",
     "either come from the Python interface of the simulation package, from\n",
     "flat files containing the results, or from package-specific parsers. See\n",
     "[SimulationData](../simulation_data.rst) for more details."
@@ -159,7 +159,7 @@
     "    units=physical_validation.data.UnitData.units(\"GROMACS\"),\n",
     "    system=system_data,\n",
     "    ensemble=ensemble_data,\n",
-    "    # The equipartition test needs position and velocity trajectories    \n",
+    "    # The equipartition test needs position and velocity trajectories\n",
     "    trajectory=physical_validation.data.TrajectoryData(\n",
     "        position=simulation[\"position\"],\n",
     "        velocity=simulation[\"velocity\"],\n",

--- a/doc/examples/kinetic_energy_equipartition.ipynb
+++ b/doc/examples/kinetic_energy_equipartition.ipynb
@@ -30,8 +30,8 @@
    "id": "2a3d8caf",
    "metadata": {},
    "source": [
-    "The results imported here are results from example simulations which are\n",
-    "stored in another Python file. In real-world usage, the results would\n",
+    "The results imported here are results from example simulations, which are\n",
+    "the time series of the kinetic/potential energy, position and velocity stored in another Python file. In real-world usage, the results would\n",
     "either come from the Python interface of the simulation package, from\n",
     "flat files containing the results, or from package-specific parsers. See\n",
     "[SimulationData](../simulation_data.rst) for more details."
@@ -65,7 +65,7 @@
    "source": [
     "`physical_validation` does not only allow to test the kinetic energy of the entire system, but also the kinetic energy of parts of the system, or how the kinetic energy is distributed within the molecules (translational, rotational and internal kinetic energy).\n",
     "\n",
-    "To demonstrate this checks, we will first look at a simulation of a Trp-cage mini-protein. This simulation was performed in water, using a single thermostat connected to the entire system (solute and solvent). Since there is significantly more solvent than solute in typical solvated simulations, unphysical behavior of the solute might be hidden due to the large amount of solvent when looking at full-system properties. We will therefore look at the trajectory which was stripped from the water in post-processing to check the kinetic energy of the solute alone.\n",
+    "To demonstrate this check, we will first look at a simulation of a Trp-cage mini-protein. This simulation was performed in water, using a single thermostat connected to the entire system (solute and solvent). Since there is significantly more solvent than solute in typical solvated simulations, unphysical behavior of the solute might be hidden due to the large amount of solvent when looking at full-system properties. We will therefore look at the trajectory which was stripped from the water in post-processing to check the kinetic energy of the solute alone.\n",
     "\n",
     "We will first load the results from the imported example simulations:"
    ]
@@ -159,7 +159,7 @@
     "    units=physical_validation.data.UnitData.units(\"GROMACS\"),\n",
     "    system=system_data,\n",
     "    ensemble=ensemble_data,\n",
-    "    # The equipartition test needs position and velocity trajectories\n",
+    "    # The equipartition test needs position and velocity trajectories    \n",
     "    trajectory=physical_validation.data.TrajectoryData(\n",
     "        position=simulation[\"position\"],\n",
     "        velocity=simulation[\"velocity\"],\n",

--- a/doc/simulation_data.rst
+++ b/doc/simulation_data.rst
@@ -316,28 +316,28 @@ System: :obj:`.SimulationData.system` of type :class:`.SystemData`
 Attributes:
 
     * :attr:`.SimulationData.natoms`, the total number of atoms in the system;
-      e.g. for a system containing 100 water molecules: `.SimulationData.natoms = 300`
+      e.g. for a system containing 100 water molecules: :attr:`.SimulationData.natoms`` = 300`
     * :attr:`.SimulationData.nconstraints`, the total number of constraints in the
       system, not including the global translational and rotational constraints
       (see next two attributes); e.g. for a system containing 100 *rigid* water molecules:
-      `.SimulationData.nconstraints = 300`
+      :attr:`.SimulationData.nconstraints`` = 300`
     * :attr:`.SimulationData.ndof_reduction_tra`, global reduction of translational
       degrees of freedom (e.g. due to constraining the center of mass of the system)
     * :attr:`.SimulationData.ndof_reduction_rot`, global reduction of rotational
       degrees of freedom (e.g. due to constraining the center of mass of the system)
     * :attr:`.SimulationData.mass`, a list of the mass of every atom in the system;
-      e.g. for a single water molecule: `.SimulationData.mass = [15.9994, 1.008, 1.008]`
+      e.g. for a single water molecule: :attr:`.SimulationData.mass`` = [15.9994, 1.008, 1.008]`
     * :attr:`.SimulationData.molecule_idx`, a list of the index of the first atom of every
       molecule (this assumes that the atoms are sorted by molecule); e.g. for a system
-      containing 3 water molecules: `.SimulationData.molecule_idx = [0, 3, 6]`
+      containing 3 water molecules: :attr:`.SimulationData.molecule_idx`` = [0, 3, 6]`
     * :attr:`.SimulationData.nconstraints_per_molecule`, a list of the number of
       constraints in every molecule; e.g. for a system containing 3 *rigid* water
-      molecules: `.SimulationData.nconstraints_per_molecule = [3, 3, 3]`
+      molecules: :attr:`.SimulationData.nconstraints_per_molecule`` = [3, 3, 3]`
     * :attr:`.SimulationData.bonds`, a list containing all bonds in the system;
       e.g. for a system containing 3 water molecules:
-      `.SimulationData.bonds = [[0, 1], [0, 2], [3, 4], [3, 5], [6, 7], [6, 8]]`
+      :attr:`.SimulationData.bonds`` = [[0, 1], [0, 2], [3, 4], [3, 5], [6, 7], [6, 8]]`
     * :attr:`.SimulationData.constrained_bonds`, a list containing only the constrained
-      bonds in the system, must be a subset of `.SimulationData.bonds` (and equal, if
+      bonds in the system, must be a subset of :attr:`.SimulationData.bonds` (and equal, if
       all bonds are constrained).
 
 .. todo:: Currently, there is some redundancy in the attributes listed above. The
@@ -364,19 +364,19 @@ Observables: :obj:`.SimulationData.observables` of type :class:`.ObservableData`
 Attributes:
 
   * :attr:`.ObservableData.kinetic_energy`, the kinetic energy trajectory (nframes x 1),
-    also accessible via `.ObservableData['kinetic_energy']`
+    also accessible via :obj:`.ObservableData['kinetic_energy']`
   * :attr:`.ObservableData.potential_energy`, the potential energy trajectory (nframes x 1),
-    also accessible via `.ObservableData['potential_energy']`
+    also accessible via :obj:`.ObservableData['potential_energy']`
   * :attr:`.ObservableData.total_energy`, the total energy trajectory (nframes x 1),
-    also accessible via `.ObservableData['total_energy']`
+    also accessible via :obj:`.ObservableData['total_energy']`
   * :attr:`.ObservableData.volume`, the volume trajectory (nframes x 1),
-    also accessible via `.ObservableData['volume']`
+    also accessible via :obj:`.ObservableData['volume']`
   * :attr:`.ObservableData.pressure` the pressure trajectory (nframes x 1),
-    also accessible via `.ObservableData['pressure']`
+    also accessible via :obj:`.ObservableData['pressure']`
   * :attr:`.ObservableData.temperature` the temperature trajectory (nframes x 1),
-    also accessible via `.ObservableData['temperature']`
+    also accessible via :obj:`.ObservableData['temperature']`
   * :attr:`.ObservableData.constant_of_motion` the constant of motion trajectory (nframes x 1),
-    also accessible via `.ObservableData['constant_of_motion']`
+    also accessible via :obj:`.ObservableData['constant_of_motion']`
 
 Needed by
 
@@ -399,9 +399,9 @@ Atom trajectories: :obj:`.SimulationData.trajectory` of type :class:`.Trajectory
 Attributes:
 
   * :attr:`.TrajectoryData.position`, the position trajectory (nframes x natoms x 3),
-    also accessible via `.TrajectoryData['position']`
+    also accessible via :obj:`.TrajectoryData['position']`
   * :attr:`.TrajectoryData.velocity`, the velocity trajectory (nframes x natoms x 3),
-    also accessible via `.TrajectoryData['velocity']`
+    also accessible via :obj:`.TrajectoryData['velocity']`
 
 Needed by
 

--- a/doc/simulation_data.rst
+++ b/doc/simulation_data.rst
@@ -69,7 +69,7 @@ velocities):
    )
 
    # This snippet is assuming that `kin_ene`, `pot_ene` and `tot_ene` are lists
-   # or numpy arrays filled with the kinetic, potential and total energy
+   # or numpy arrays filled with the time series of kinetic, potential and total energy
    # of a simulation run. These might be obtained, e.g., from the python
    # API of a simulation code, or from other python-based analysis tools.
    simulation_data.observables = physical_validation.data.ObservableData(
@@ -327,10 +327,10 @@ Attributes:
       degrees of freedom (e.g. due to constraining the center of mass of the system)
     * :attr:`.SimulationData.mass`, a list of the mass of every atom in the system;
       e.g. for a single water molecule: `.SimulationData.mass = [15.9994, 1.008, 1.008]`
-    * :attr:`.SimulationData.molecule_idx`, a list with the indices first atoms of every
+    * :attr:`.SimulationData.molecule_idx`, a list of the index of the first atom of every
       molecule (this assumes that the atoms are sorted by molecule); e.g. for a system
       containing 3 water molecules: `.SimulationData.molecule_idx = [0, 3, 6]`
-    * :attr:`.SimulationData.nconstraints_per_molecule`, a list with the number of
+    * :attr:`.SimulationData.nconstraints_per_molecule`, a list of the number of
       constraints in every molecule; e.g. for a system containing 3 *rigid* water
       molecules: `.SimulationData.nconstraints_per_molecule = [3, 3, 3]`
     * :attr:`.SimulationData.bonds`, a list containing all bonds in the system;

--- a/doc/simulation_data.rst
+++ b/doc/simulation_data.rst
@@ -28,10 +28,7 @@ directly from arrays and numbers, or (partially) automatically via parsers.
 Create SimulationData objects from python data
 ----------------------------------------------
 
-Example usage, system of 900 water molecules in GROMACS units simulated in
-NVT (note that this example leaves some fields in :class:`.SystemData`
-empty, as well as the trajectory of some observables and the position and
-velocities):
+Example usage, system of 900 water molecules in GROMACS units simulated in NVT:
 ::
 
    import numpy as np
@@ -241,6 +238,41 @@ velocities):
        potential_ene_file='potential.dat',
        total_ene_file='total.dat'
    )
+
+Additional examples
+-------------------
+
+Use :code:`MDAnalysis` to create mass vector
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Using :code:`MDAnalysis`, creating a mass vector which can be fed to
+:attr:`.SimulationData.mass` is straightforward. See the following snippet
+for an example using a GROMACS topology:
+::
+
+   import MDAnalysis as mda
+   import numpy as np
+
+   u = mda.Universe('system.gro')
+   mass=np.array([u.atoms[i].mass for i in range(len(u.atoms))])
+
+Use :code:`MDAnalysis` to define molecule groups for equipartition testing
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:func:`physical_validation.kinetic_energy.equipartition` allows to specify
+molecule groups which can be tested for equipartition. The segments used in
+:code:`MDAnalysis` can easily be used to define molecule groups as input to
+the equipartition check:
+::
+
+   import MDAnalysis as mda
+   import numpy as np
+
+   u = mda.Universe('system.tpr', 'system.gro')
+   molec_groups = []
+   for i in range(len(u.segments)):
+       seg = u.segments[i]
+       molec_groups.append(np.array([seg.atoms[j].index for j in range(len(seg.atoms))]))
 
 
 .. _simulationdata_details:

--- a/physical_validation/data/observable_data.py
+++ b/physical_validation/data/observable_data.py
@@ -26,7 +26,7 @@ class ObservableData(object):
     r"""ObservableData: The trajectory of (macroscopic) observables during the simulation
 
     Stores a number of different observables:
-    
+
     * kinetic_energy: the kinetic energy of the system,
     * potential_energy: the potential energy of the system,
     * total_energy: the total energy of the system,

--- a/physical_validation/data/observable_data.py
+++ b/physical_validation/data/observable_data.py
@@ -26,6 +26,7 @@ class ObservableData(object):
     r"""ObservableData: The trajectory of (macroscopic) observables during the simulation
 
     Stores a number of different observables:
+    
     * kinetic_energy: the kinetic energy of the system,
     * potential_energy: the potential energy of the system,
     * total_energy: the total energy of the system,

--- a/physical_validation/data/system_data.py
+++ b/physical_validation/data/system_data.py
@@ -24,7 +24,7 @@ from ..util import error as pv_error
 class SystemData(object):
     r"""SystemData: Information about the atoms and molecules in the system.
 
-    The information stored in SystemData objects describes the atom and molecules
+    The information stored in SystemData objects describes the atoms and molecules
     in the system as far as the physical validation tests need it.
 
     The system is described in terms of

--- a/physical_validation/integrator.py
+++ b/physical_validation/integrator.py
@@ -11,7 +11,7 @@
 #                                                                         #
 ###########################################################################
 """
-The `integratorconvergence` module is part of the physical_validation
+The `integrator.convergence` module is part of the physical_validation
 package, and consists of checks of the convergence of the MD integrator.
 """
 from typing import List, Optional


### PR DESCRIPTION
## Description
As the final check of the documentation, in this PR I've fixed some typos and format issues and added additional explanatory texts in some of the `rst` files and jupyter notebooks. In the documentation, I've also indicated that the error estimates of the temperatures calculated in the non-strict kinetic distribution test will not be exactly reproducible if no random seed is set through the option `bootstrap_seed`. Overall, I think the documentation and the jupyter notebooks are very clear and straightforward. (There is an issue with one of the notebooks as mentioned below.) I've only found a few things that could be done to marginally improve the documentation. In the next section, I've listed some discussion points in the order of importance with the last few being the least important ones. 

## Discussion points
- ~~The first half (Trp-cage example) of the notebook `kinetic_energy_equipartition.ipynb` is not executable, which I believe the main reason is that the potential/kinetic energies are not read in such that `simulation_data.observables` is `None` and does not have the attribute `kinetic_energy_per_molecule`. However, the energy data is missing from `trp-cage.py`  and I did not find any raw data of the simulation such that I could create arrays of energy and add them to `trp-cage.py`. I could potentially use the GROMACS parser to parse `run.edr` in the repo `physical_validation_workshop`, but in our new documentation, it was not clear which kind of thermostat was used and there are two options available in the workshop repo (be and vr), so I was not sure which set of simulation data I should use.~~ → **Resolved: Was due to an outdated version.**
- ~~We might want to show how the trajectory data (kinetic energy, potential energy, and total energy) can be obtained from a python interface of the simulation package (maybe at least for GROMACS). This might not be immediately straightforward to the beginners of the field. We could potentially add a notebook showing different ways of reading in the simulation data and show that the results of importing the data are the same.~~ → **Decided to leave this for now, probably out of scope of our documentation.**
- The issue with the previous documentation was that it relied on package-specific parsers too much. I'm wondering if in the new documentation we want to encourage creating SimulationData objects from python data. If so, we might want to talk more about creating an array for the argument `mass` to the `SystemData` object. Currently, the example shown in the documentation is the 900-water example, so the creation of the array `mass` is straightforward. However, for a more complicated example (like a protein-ligand binding complex), we might want to mention how to efficiently create such an array other than using the GROMACS parser. However, if we are just pointing out that it is possible to create `SimulationData ` from python data even if it could be more tedious than using a package-specific parser, then I think it's reasonable to not mention the creation of the array mass. (The creation of such an array is pretty easy anyway so this issue might be trivial though.)
- For the function `physical_validation.kinetic_energy.equipartition`, I was wondering if it would be useful that the user is allowed to specify `molec_groups`  with a string like `LIG`, `SOL`, or any molecule names that can be found in the GROMACS topology file. That is, if `molec_groups` is a string,  we parse the topology file and find the corresponding atom indices. If the given string is not shown in the topology file, the function returns an error. Or do we actually want the leave this task to the users such that they should parse their topology file by themselves to get the array to be passed to the function? This is not urgent anyway.
- ~~Can `GrommacsParser`  read in xtc  files? Some people might prefer to output the simulation trajectory as an xtc  file rather than a trr file due to a smaller size. Those users could convert the xtc file to a gro file trajectory since reading a gro  file trajectory seems to be the other option though.~~ → **Rejected: xtc files are not helpful, because they lack velocity data. Physical validation tests either use positions and velocities, or don't need the trajectory at all.**
- ~~In the section of "Simulation data", the sentence "The different physical validation tests do not all require all data to be able to run" could probably be more clear. If I understand correctly, this just means that some tests (integrator and ensemble validation) only require mdp, top, gro and edr files, while some other tests (equipartition) did not require a gro file but the trajectory file (trr file). I have not made any changes for this sentence but I think maybe we could explicitly mention the required inputs for different tests. (Maybe we can use bullet points?)~~ → **See #186**
- ~~For a lot of attributes list on the page of Data Format and Parsers, there are a lot of times that a certain function or attribute are mentioned but with an italic font instead of an inline code. Do we want to term them into inline codes (i.e. add `:attr:` or `:func:` before each singly-quoted statement)? (Example: `ObservableData.kinetic_energy`, the kinetic energy trajectory (nframes x 1), also accessible via *.ObservableData[‘kinetic_energy’]*) )~~ → **Fixed by Wei-Tse!**
- ~~This is minor as well, but I just felt that when plotting probability distributions of the samples obtained in the simulation, the number of bins could be higher to show its consistency (or inconsistency) with the expected distribution more easily (especially the ones in the kinetic energy equipartition example now shown in the documentation). This might involve how flexible we want our code to be in terms of specifying the settings of the plots.~~ → **Binning has been improved since:  #164**

## Todos
  - [x] Go over the discussion points and make further changes as needed. 
  - [x] I've just found that I accidentally added `r` at the beginning of line 13, which leads to the failure of the linting check. I've fixed that in the next commit. 
  - [x] Clarify the sentence "The different physical validation tests do not all require all data to be able to run" in the section of "Simulation data".

## Status
- [x] Ready to go