### PR TITLE
Allow multidimensional trajectories to skip preparation

### DIFF
--- a/physical_validation/util/trajectory.py
+++ b/physical_validation/util/trajectory.py
@@ -138,12 +138,6 @@ def prepare(
         else:
             return t.shape[1]
 
-    if traj.ndim > 2:
-        raise NotImplementedError(
-            "trajectory.prepare() is not implemented for "
-            "trajectories with more than 2 dimensions."
-        )
-
     if skip_preparation:
         if verbosity > 0:
             print(
@@ -153,6 +147,12 @@ def prepare(
                 "be invalid."
             )
         return traj
+
+    if traj.ndim > 2:
+        raise NotImplementedError(
+            "trajectory.prepare() is not implemented for "
+            "trajectories with more than 2 dimensions."
+        )
 
     # original length
     n0 = traj_length(traj)


### PR DESCRIPTION
This switches the order of the checks during trajectory preparation:
Until now, it was first checked whether there were more than 2 dimensions
(for which preparation is not implemented), and after whether preparation
should be skipped. This is now inverted, as it isn't necessary to abort
trajectory preparation if it shouldn't be performed in the first place.

## Status
- [ ] Ready to go