### PR TITLE
Prepare ensemble data structure to accept muVT

### DIFF
--- a/physical_validation/data/ensemble_data.py
+++ b/physical_validation/data/ensemble_data.py
@@ -16,6 +16,8 @@ Data structures carrying simulation data.
 import warnings
 from typing import Tuple
 
+import numpy as np
+
 from ..util import error as pv_error
 
 
@@ -96,7 +98,8 @@ class EnsembleData(object):
                 warnings.warn(ensemble + " with undefined volume.")
             if temperature is None:
                 warnings.warn(ensemble + " with undefined temperature.")
-            self.__mu = mu
+            if mu is not None:
+                self.__mu = np.array([mu]).flatten()
             self.__v = volume
             self.__t = temperature
 
@@ -111,7 +114,7 @@ class EnsembleData(object):
         return self.__n
 
     @property
-    def mu(self) -> float:
+    def mu(self) -> np.ndarray:
         """Get mu"""
         return self.__mu
 

--- a/physical_validation/data/simulation_data.py
+++ b/physical_validation/data/simulation_data.py
@@ -241,6 +241,7 @@ class SimulationData(object):
         test_name: str,
         argument_name: str,
         check_pressure: bool,
+        check_mu: bool,
     ) -> None:
         r"""
         Raise InputError if the ensemble data does not hold the required
@@ -254,6 +255,8 @@ class SimulationData(object):
             String naming the SimulationData argument used for error output
         check_pressure
             Whether to check if the pressure is defined (NPT only).
+        check_mu
+            Whether to check if the chemical potential is defined (muVT only).
         """
         if self.ensemble is None:
             raise pv_error.InputError(
@@ -261,7 +264,7 @@ class SimulationData(object):
                 f"SimulationData object provided to {test_name} does not contain "
                 f"information about the sampled ensemble.",
             )
-        for ensemble in "NVT", "NPT":
+        for ensemble in "NVT", "NPT", "muVT":
             if self.ensemble.ensemble == ensemble and self.ensemble.temperature is None:
                 raise pv_error.InputError(
                     argument_name,
@@ -277,6 +280,13 @@ class SimulationData(object):
                 argument_name,
                 f"SimulationData object provided to {test_name} indicates it was sampled "
                 f"from an NPT ensemble, but does not specify the pressure.",
+            )
+
+        if self.ensemble.ensemble == "muVT" and check_mu and self.ensemble.mu is None:
+            raise pv_error.InputError(
+                argument_name,
+                f"SimulationData object provided to {test_name} indicates it was sampled "
+                f"from an muVT ensemble, but does not specify the chemical potential.",
             )
 
     def raise_if_system_data_is_invalid(

--- a/physical_validation/ensemble.py
+++ b/physical_validation/ensemble.py
@@ -102,11 +102,13 @@ def check(
         test_name="ensemble.check",
         argument_name="data_sim_one",
         check_pressure=True,
+        check_mu=True,
     )
     data_sim_two.raise_if_ensemble_is_invalid(
         test_name="ensemble.check",
         argument_name="data_sim_two",
         check_pressure=True,
+        check_mu=True,
     )
 
     if data_sim_one.ensemble.ensemble != data_sim_two.ensemble.ensemble:
@@ -120,7 +122,7 @@ def check(
 
     sampled_ensemble = data_sim_one.ensemble.ensemble
 
-    if sampled_ensemble == "NVE" or sampled_ensemble == "muVT":
+    if not (sampled_ensemble == "NVT" or sampled_ensemble == "NPT"):
         raise NotImplementedError(
             "Test of ensemble " + sampled_ensemble + " is not implemented (yet).",
         )
@@ -379,6 +381,7 @@ def estimate_interval(
         test_name="ensemble.estimate_interval",
         argument_name="data",
         check_pressure=True,
+        check_mu=True,
     )
     if not (data.ensemble.ensemble == "NVT" or data.ensemble.ensemble == "NPT"):
         raise NotImplementedError(

--- a/physical_validation/kinetic_energy.py
+++ b/physical_validation/kinetic_energy.py
@@ -134,6 +134,7 @@ def distribution(
         test_name="kinetic_energy.distribution",
         argument_name="data",
         check_pressure=False,
+        check_mu=False,
     )
     data.raise_if_system_data_is_invalid(
         test_name="kinetic_energy.distribution",
@@ -289,6 +290,7 @@ def equipartition(
         test_name="kinetic_energy.equipartition",
         argument_name="data",
         check_pressure=False,
+        check_mu=False,
     )
     data.raise_if_system_data_is_invalid(
         test_name="kinetic_energy.equipartition",

--- a/physical_validation/tests/test_data_simulation_data.py
+++ b/physical_validation/tests/test_data_simulation_data.py
@@ -142,7 +142,10 @@ class TestInvalidityChecks:
             )
         with pytest.raises(pv_error.InputError):
             simulation_data.raise_if_ensemble_is_invalid(
-                test_name="dummy_test", argument_name="data", check_pressure=True
+                test_name="dummy_test",
+                argument_name="data",
+                check_pressure=True,
+                check_mu=True,
             )
         with pytest.raises(pv_error.InputError):
             simulation_data.raise_if_system_data_is_invalid(
@@ -169,55 +172,158 @@ class TestInvalidityChecks:
         # NVE isn't tested, so passes always
         simulation_data.ensemble = EnsembleData(ensemble="NVE")
         simulation_data.raise_if_ensemble_is_invalid(
-            test_name="dummy_test", argument_name="data", check_pressure=True
-        )
-        # muVT isn't tested, so passes always
-        simulation_data.ensemble = EnsembleData(ensemble="muVT")
-        simulation_data.raise_if_ensemble_is_invalid(
-            test_name="dummy_test", argument_name="data", check_pressure=True
+            test_name="dummy_test",
+            argument_name="data",
+            check_pressure=True,
+            check_mu=True,
         )
         # NVT doesn't pass without temperature
         simulation_data.ensemble = EnsembleData(ensemble="NVT")
         with pytest.raises(pv_error.InputError):
             simulation_data.raise_if_ensemble_is_invalid(
-                test_name="dummy_test", argument_name="data", check_pressure=False
+                test_name="dummy_test",
+                argument_name="data",
+                check_pressure=True,
+                check_mu=True,
             )
         # Adding temperature fixes it
         simulation_data.ensemble = EnsembleData(ensemble="NVT", temperature=300)
         simulation_data.raise_if_ensemble_is_invalid(
-            test_name="dummy_test", argument_name="data", check_pressure=True
+            test_name="dummy_test",
+            argument_name="data",
+            check_pressure=True,
+            check_mu=True,
         )
         # NPT doesn't pass without temperature
         simulation_data.ensemble = EnsembleData(ensemble="NPT")
         with pytest.raises(pv_error.InputError):
             simulation_data.raise_if_ensemble_is_invalid(
-                test_name="dummy_test", argument_name="data", check_pressure=False
+                test_name="dummy_test",
+                argument_name="data",
+                check_pressure=False,
+                check_mu=True,
             )
         # Adding temperature fixes it if check_pressure is False
         simulation_data.ensemble = EnsembleData(ensemble="NPT", temperature=300)
         simulation_data.raise_if_ensemble_is_invalid(
-            test_name="dummy_test", argument_name="data", check_pressure=False
+            test_name="dummy_test",
+            argument_name="data",
+            check_pressure=False,
+            check_mu=True,
         )
         # But not if pressure is required to be tested
         with pytest.raises(pv_error.InputError):
             simulation_data.raise_if_ensemble_is_invalid(
-                test_name="dummy_test", argument_name="data", check_pressure=True
+                test_name="dummy_test",
+                argument_name="data",
+                check_pressure=True,
+                check_mu=True,
             )
         # Pressure alone doesn't help
         simulation_data.ensemble = EnsembleData(ensemble="NPT", pressure=1.0)
         with pytest.raises(pv_error.InputError):
             simulation_data.raise_if_ensemble_is_invalid(
-                test_name="dummy_test", argument_name="data", check_pressure=True
+                test_name="dummy_test",
+                argument_name="data",
+                check_pressure=True,
+                check_mu=True,
             )
         # Temperature and pressure passes
         simulation_data.ensemble = EnsembleData(
             ensemble="NPT", temperature=300, pressure=1.0
         )
         simulation_data.raise_if_ensemble_is_invalid(
-            test_name="dummy_test", argument_name="data", check_pressure=False
+            test_name="dummy_test",
+            argument_name="data",
+            check_pressure=False,
+            check_mu=True,
         )
         simulation_data.raise_if_ensemble_is_invalid(
-            test_name="dummy_test", argument_name="data", check_pressure=True
+            test_name="dummy_test",
+            argument_name="data",
+            check_pressure=True,
+            check_mu=True,
+        )
+        # muVT doesn't pass without temperature
+        simulation_data.ensemble = EnsembleData(ensemble="muVT")
+        with pytest.raises(pv_error.InputError):
+            simulation_data.raise_if_ensemble_is_invalid(
+                test_name="dummy_test",
+                argument_name="data",
+                check_pressure=True,
+                check_mu=False,
+            )
+        # But passes with temperature if mu is not tested
+        simulation_data.ensemble = EnsembleData(ensemble="muVT", temperature=300)
+        simulation_data.raise_if_ensemble_is_invalid(
+            test_name="dummy_test",
+            argument_name="data",
+            check_pressure=True,
+            check_mu=False,
+        )
+        # And fails again if mu is required
+        simulation_data.ensemble = EnsembleData(ensemble="muVT", temperature=300)
+        with pytest.raises(pv_error.InputError):
+            simulation_data.raise_if_ensemble_is_invalid(
+                test_name="dummy_test",
+                argument_name="data",
+                check_pressure=True,
+                check_mu=True,
+            )
+        # And fails also if mu is specified, but not the temperature
+        simulation_data.ensemble = EnsembleData(ensemble="muVT", mu=0.8)
+        with pytest.raises(pv_error.InputError):
+            simulation_data.raise_if_ensemble_is_invalid(
+                test_name="dummy_test",
+                argument_name="data",
+                check_pressure=True,
+                check_mu=True,
+            )
+        # With both specified, it passes with different types of mu input
+        simulation_data.ensemble = EnsembleData(
+            ensemble="muVT", mu=0.8, temperature=300
+        )
+        simulation_data.raise_if_ensemble_is_invalid(
+            test_name="dummy_test",
+            argument_name="data",
+            check_pressure=True,
+            check_mu=True,
+        )
+        simulation_data.ensemble = EnsembleData(
+            ensemble="muVT", mu=[0.8], temperature=300
+        )
+        simulation_data.raise_if_ensemble_is_invalid(
+            test_name="dummy_test",
+            argument_name="data",
+            check_pressure=True,
+            check_mu=True,
+        )
+        simulation_data.ensemble = EnsembleData(
+            ensemble="muVT", mu=np.array([0.8]), temperature=300
+        )
+        simulation_data.raise_if_ensemble_is_invalid(
+            test_name="dummy_test",
+            argument_name="data",
+            check_pressure=True,
+            check_mu=True,
+        )
+        simulation_data.ensemble = EnsembleData(
+            ensemble="muVT", mu=[0.8, 0.5], temperature=300
+        )
+        simulation_data.raise_if_ensemble_is_invalid(
+            test_name="dummy_test",
+            argument_name="data",
+            check_pressure=True,
+            check_mu=True,
+        )
+        simulation_data.ensemble = EnsembleData(
+            ensemble="muVT", mu=np.array([0.8, 0.5]), temperature=300
+        )
+        simulation_data.raise_if_ensemble_is_invalid(
+            test_name="dummy_test",
+            argument_name="data",
+            check_pressure=True,
+            check_mu=True,
         )
 
     @staticmethod


### PR DESCRIPTION
## Description
To allow for muVT, we need the `EnsembleData` objects to accept this ensemble.

## Status
- [x] Ready to go