### PR TITLE
Fix documentation error

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,6 +5,12 @@
 # Required
 version: 2
 
+# Set the version of Python and other tools you might need
+build:
+   os: ubuntu-20.04
+   tools:
+      python: "3.9"
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
    configuration: doc/conf.py
@@ -17,4 +23,5 @@ formats:
 # Optionally set the version of Python and requirements required to build your docs
 python:
    install:
+   - requirements: requirements.txt
    - requirements: doc/requirements.txt

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,5 +1,3 @@
-numpy
-scipy
-matplotlib
-pymbar
-nbsphinx
+sphinx==4.2.0
+nbsphinx==0.8.7
+sphinx_rtd_theme==1.0.0


### PR DESCRIPTION
RTD documentation were failing since about two weeks, related to
https://github.com/sphinx-doc/sphinx/issues/9727. RTD does by default
keep sphinx at version < 2 for existing projects. Older versions of
sphinx do no define their version dependency on docutils. docutils, in
turn, was recently updated breaking compatibility with sphinx.

This change cleans up the dependencies of the RTD build, updating and
pinning the versions of the dependencies. This should make the
documentation builds stable and reproducible.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] Check RTD build to make sure this doesn't break anything.

## Status
- [ ] Ready to go