### PR TITLE
Fix lgtm.com analysis

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -8,3 +8,10 @@ path_classifiers:
   # LGTM ignores any file having a tag. Since we want test files to be checked, we
   # exclude all files from the test tag, making sure that LGTM doesn't find any tests
     - exclude: /
+
+extraction:
+  python:
+    index:
+      exclude:
+      # The example files are very big (up to ~18M), and tend to choke up LGTM
+        - doc/examples/simulation_results


### PR DESCRIPTION
The large example files in doc/examples/simulation_results make
the lgtm.com analysis time out. This fixes this by excluding them
from the analysis.

## Todos
  - [x] Check that lgtm.com analysis runs through now.

## Status
- [x] Ready to go