### PR TITLE
Add installation instructions for conda

### DIFF
--- a/doc/userguide.rst
+++ b/doc/userguide.rst
@@ -53,6 +53,14 @@ via :code:`pip`
 
    pip install physical_validation
 
+conda
+-----
+The most recent release of `physical_validation` can also be installed using
+:code:`conda`
+::
+
+   conda install -c conda-forge physical_validation
+
 Development version
 -------------------
 


### PR DESCRIPTION
Refs #2, #63

## To do
- [x] Have our recipe merged at https://github.com/conda-forge/staged-recipes/pull/11370

## Questions
~~Shall we merge this and #192 and release version 1.0.0, and then get our conda recipe merged? Or first get the recipe merged, and then release this? I guess that depends how frowned upon it is to bump the version number of our recipe right after it got first approved! It's not great to put up installation instructions that don't work yet, but if it's just a matter of days, I wouldn't mind too much.~~ → As suggested by Matt, we will release this as a patch release once the recipe is merged and available.

## Status
- [x] Ready to go