### PR TITLE
Make physical_validation compatible to pymbar versions 3 and 4

### DIFF
--- a/.github/workflows/continous_integration.yaml
+++ b/.github/workflows/continous_integration.yaml
@@ -27,7 +27,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           activate-environment: test-pymbar${{ matrix.pymbar-version }}
           channel-priority: true
-          environment-file: devtools/conda-envs/test_env.yaml
+          environment-file: devtools/conda-envs/test-pymbar${{ matrix.pymbar-version }}_env.yaml
           auto-activate-base: false
 
       - name: Additional info about the build

--- a/.github/workflows/continous_integration.yaml
+++ b/.github/workflows/continous_integration.yaml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os: ["macOS-latest", "ubuntu-latest"]
         python-version: ["3.7", "3.8", "3.9", "3.10"]
-        pymbar-version: ["3", "4"]
+        pymbar-version: ["pymbar3", "pymbar4"]
 
     steps:
       - uses: actions/checkout@v3
@@ -25,9 +25,9 @@ jobs:
         uses: conda-incubator/setup-miniconda@v2.1.1
         with:
           python-version: ${{ matrix.python-version }}
-          activate-environment: test-pymbar${{ matrix.pymbar-version }}
+          activate-environment: test-${{ matrix.pymbar-version }}
           channel-priority: true
-          environment-file: devtools/conda-envs/test-pymbar${{ matrix.pymbar-version }}_env.yaml
+          environment-file: devtools/conda-envs/test-${{ matrix.pymbar-version }}_env.yaml
           auto-activate-base: false
 
       - name: Additional info about the build

--- a/.github/workflows/continous_integration.yaml
+++ b/.github/workflows/continous_integration.yaml
@@ -16,6 +16,7 @@ jobs:
       matrix:
         os: ["macOS-latest", "ubuntu-latest"]
         python-version: ["3.7", "3.8", "3.9", "3.10"]
+        pymbar-version: ["3", "4"]
 
     steps:
       - uses: actions/checkout@v3
@@ -24,7 +25,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v2.1.1
         with:
           python-version: ${{ matrix.python-version }}
-          activate-environment: test
+          activate-environment: test-pymbar${{ matrix.pymbar-version }}
           channel-priority: true
           environment-file: devtools/conda-envs/test_env.yaml
           auto-activate-base: false

--- a/devtools/conda-envs/test-pymbar3_env.yaml
+++ b/devtools/conda-envs/test-pymbar3_env.yaml
@@ -1,4 +1,4 @@
-name: test
+name: test-pymbar3
 channels:
   - conda-forge
   - bioconda
@@ -18,4 +18,4 @@ dependencies:
   - numpy
   - scipy
   - matplotlib
-  - pymbar <4  # See issue #216
+  - pymbar >=3,<4  # See issue #216

--- a/devtools/conda-envs/test-pymbar4_env.yaml
+++ b/devtools/conda-envs/test-pymbar4_env.yaml
@@ -1,0 +1,21 @@
+name: test-pymbar4
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+    # Base depends
+  - python
+  - pip
+
+    # Testing and development
+  - pytest
+  - pytest-cov
+  - pytest-regressions
+  - codecov
+  - gromacs
+
+    # Standard dependencies
+  - numpy
+  - scipy
+  - matplotlib
+  - pymbar >=4

--- a/physical_validation/util/ensemble.py
+++ b/physical_validation/util/ensemble.py
@@ -19,7 +19,16 @@ serves as the low-level functionality of the high-level module
 from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np
-import pymbar
+
+try:
+    # pymbar >= 4
+    from pymbar.other_estimators import bar
+    from pymbar.timeseries import statistical_inefficiency
+except ImportError:
+    # pymbar < 4
+    from pymbar.timeseries import statisticalInefficiency as statistical_inefficiency
+    from pymbar import BAR as bar
+
 import scipy.optimize
 
 from . import error as pv_error
@@ -979,15 +988,15 @@ def check_1d(
         )
 
     # calculate inefficiency
-    g1 = pymbar.timeseries.statisticalInefficiency(traj1)
-    g2 = pymbar.timeseries.statisticalInefficiency(traj2)
+    g1 = statistical_inefficiency(traj1)
+    g2 = statistical_inefficiency(traj2)
 
     w_f = -trueslope * traj1
     w_r = trueslope * traj2
 
     if verbosity > 2:
         print("Computing log of partition functions using pymbar.BAR...")
-    df, ddf = pymbar.BAR(w_f, w_r)
+    df, ddf = bar(w_f, w_r)
     if verbosity > 2:
         print(
             "Using {:.5f} for log of partition functions as computed from BAR.".format(
@@ -1104,8 +1113,8 @@ def check_1d(
         # use overlap region
         t1, t2, min_ene, max_ene = trajectory.overlap(traj1=t1, traj2=t2)
         # calculate inefficiency
-        g1 = pymbar.timeseries.statisticalInefficiency(t1)
-        g2 = pymbar.timeseries.statisticalInefficiency(t2)
+        g1 = statistical_inefficiency(t1)
+        g2 = statistical_inefficiency(t2)
         # calculate max_likelihood fit
         fv, _ = do_max_likelihood_fit(
             t1,
@@ -1388,14 +1397,14 @@ def check_2d(
     # calculate inefficiency
     g1 = np.array(
         [
-            pymbar.timeseries.statisticalInefficiency(traj1[0]),
-            pymbar.timeseries.statisticalInefficiency(traj1[1]),
+            statistical_inefficiency(traj1[0]),
+            statistical_inefficiency(traj1[1]),
         ]
     )
     g2 = np.array(
         [
-            pymbar.timeseries.statisticalInefficiency(traj2[0]),
-            pymbar.timeseries.statisticalInefficiency(traj2[1]),
+            statistical_inefficiency(traj2[0]),
+            statistical_inefficiency(traj2[1]),
         ]
     )
 
@@ -1404,7 +1413,7 @@ def check_2d(
 
     if verbosity > 2:
         print("Computing log of partition functions using pymbar.BAR...")
-    df, ddf = pymbar.BAR(w_f, w_r)
+    df, ddf = bar(w_f, w_r)
     if verbosity > 2:
         print(
             "Using {:.5f} for log of partition functions as computed from BAR.".format(
@@ -1474,14 +1483,14 @@ def check_2d(
         # calculate inefficiency
         g1 = np.array(
             [
-                pymbar.timeseries.statisticalInefficiency(t1[0]),
-                pymbar.timeseries.statisticalInefficiency(t1[1]),
+                statistical_inefficiency(t1[0]),
+                statistical_inefficiency(t1[1]),
             ]
         )
         g2 = np.array(
             [
-                pymbar.timeseries.statisticalInefficiency(t2[0]),
-                pymbar.timeseries.statisticalInefficiency(t2[1]),
+                statistical_inefficiency(t2[0]),
+                statistical_inefficiency(t2[1]),
             ]
         )
         # calculate max_likelihood fit


### PR DESCRIPTION
## Description
Pymbar 4 introduced API-breaking changes, making physical_validation incompatible with pymbar versions >= 4.

This change makes the physical_validation code agnostic to the pymbar version, using try/catch blocks for the relevant imports and adding a helper function wrapping the call to the pymbar BAR functionality.

This also extends our CI to test for both pymbar versions we intend to support.

Fixes #216.

## Status
- [x] Ready to go