### PR TITLE
Clean up references to master branch

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "main" ]
   schedule:
     - cron: "38 20 * * 6"
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![GitHub Actions Test Status](https://github.com/shirtsgroup/physical_validation/actions/workflows/continous_integration.yaml/badge.svg)](https://github.com/shirtsgroup/physical_validation/actions/workflows/continous_integration.yaml)
 [![GitHub Actions Lint Status](https://github.com/shirtsgroup/physical_validation/actions/workflows/lint.yaml/badge.svg)](https://github.com/shirtsgroup/physical_validation/actions/workflows/lint.yaml)
 [![Documentation Status](https://readthedocs.org/projects/physical-validation/badge/?version=latest)](https://physical-validation.readthedocs.io/en/latest/?badge=latest)
-[![codecov](https://codecov.io/gh/shirtsgroup/physical_validation/branch/master/graph/badge.svg)](https://codecov.io/gh/shirtsgroup/physical_validation)  
+[![codecov](https://codecov.io/gh/shirtsgroup/physical_validation/branch/main/graph/badge.svg)](https://codecov.io/gh/shirtsgroup/physical_validation)  
 [![DOI](https://zenodo.org/badge/90674371.svg)](https://zenodo.org/badge/latestdoi/90674371) [![DOI](https://joss.theoj.org/papers/10.21105/joss.03981/status.svg)](https://doi.org/10.21105/joss.03981)  
 [![MIT license](https://img.shields.io/badge/License-MIT-blue.svg)](https://lbesson.mit-license.org/)
 


### PR DESCRIPTION
After renaming the default branch from master to main, this cleans up references to the old branch name in the README file and the CodeQL action configuration file.

Fixes #225

## TODO
- [x] Check that the CodeQL action passes
- [ ] Update the default branch on CodeCov (it seems it might need a moment to update its list of branches, I couldn't yet make the change last I checked)

## Status
- [x] Ready to go